### PR TITLE
Add play page with dynamic R3F canvas

### DIFF
--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -1,0 +1,15 @@
+import dynamic from 'next/dynamic';
+import type { NextPage } from 'next';
+
+const Canvas = dynamic(() => import('@react-three/fiber').then((mod) => mod.Canvas), { ssr: false });
+
+export const PlayPage: NextPage = () => (
+  <div className="w-screen h-screen">
+    <Canvas className="w-full h-full">
+      <ambientLight />
+      <pointLight position={[10, 10, 10]} />
+    </Canvas>
+  </div>
+);
+
+export default PlayPage;


### PR DESCRIPTION
## Summary
- add a `play` route with a full-screen Canvas

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4e2da6dc832ea0575baa71670f21