### PR TITLE
Add useTimer hook

### DIFF
--- a/hooks/useTimer.ts
+++ b/hooks/useTimer.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useTimer() {
+  const [timeElapsed, setTimeElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const runningRef = useRef(false);
+
+  const start = () => {
+    if (!runningRef.current) {
+      runningRef.current = true;
+      intervalRef.current = setInterval(() => {
+        setTimeElapsed((prev) => prev + 1);
+      }, 1000);
+    }
+  };
+
+  const pause = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+      runningRef.current = false;
+    }
+  };
+
+  const reset = () => {
+    pause();
+    setTimeElapsed(0);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return { timeElapsed, start, pause, reset };
+}


### PR DESCRIPTION
## Summary
- implement a reusable `useTimer` hook for React

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4e4746c8832e9a354e95576f0b57