### PR TITLE
Fix TypeScript config and Play page

### DIFF
--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -3,9 +3,9 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import GameCanvas from '@/components/GameCanvas';
 import UIControls from '@/components/UIControls';
-import usePuzzle from '@/hooks/usePuzzle';
-import useTimer from '@/hooks/useTimer';
+import { usePuzzle } from '@/hooks/usePuzzle';
 import { isSolved } from '@/lib/puzzle';
+import { useTimer } from '@/hooks';
 
 const PlayPage: NextPage = () => {
   const router = useRouter();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,9 +18,19 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "noEmit": true,
+    "esModuleInterop": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- update compiler options in `tsconfig.json`
- fix import paths and typing for the Play page

## Testing
- `npm run build` *(fails: next not found)*
- `npm run dev` *(fails: next not found)*
- `npm run export` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fd7a8a0a4832e85e952a0af30bad0