### PR TITLE
Improve homepage layout and styling

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import Head from 'next/head';
 
 const HomePage = () => {
   const router = useRouter();
@@ -10,14 +11,24 @@ const HomePage = () => {
   };
 
   return (
-    <div className="flex items-center justify-center h-screen">
-      <button
-        onClick={startNewGame}
-        className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-      >
-        Start New Game
-      </button>
-    </div>
+    <>
+      <Head>
+        <title>SlideCube 3D</title>
+        <meta name="description" content="A 3D Sliding-Tile Puzzle with infinite challenges." />
+      </Head>
+      <div className="h-screen w-screen bg-gradient-to-br from-blue-500 to-purple-600 flex flex-col items-center justify-center overflow-hidden">
+        <h1 className="text-5xl font-bold text-white mb-4">SlideCube 3D</h1>
+        <p className="text-lg text-white mb-8">
+          A 3D Sliding-Tile Puzzle with infinite challenges.
+        </p>
+        <button
+          onClick={startNewGame}
+          className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white text-xl rounded-xl shadow-lg hover:shadow-2xl transition"
+        >
+          Start New Game
+        </button>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- style landing page with gradient hero layout
- add Head metadata
- keep `Start New Game` button with upgraded styling

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd7e09e3c832ea05ba3a0b5375509