### PR TITLE
Display cube numbers

### DIFF
--- a/components/GameCanvas.tsx
+++ b/components/GameCanvas.tsx
@@ -32,7 +32,7 @@ const Tile: React.FC<TileProps> = ({ index, value, size, cubeSize, onClick }) =>
       <meshStandardMaterial color="orange" />
       <Text
         position={[0, cubeSize / 2 + 0.01, 0]}
-        rotation={[Math.PI / 2, Math.PI, 0]}
+        rotation={[Math.PI / 2, Math.PI, Math.PI]}
         fontSize={cubeSize * 0.4}
         color="white"
         anchorX="center"


### PR DESCRIPTION
## Summary
- show puzzle tile numbers on each cube using `<Text>` from drei

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff09d80dc832ea6b6a91dff86d71b