### PR TITLE
Fix tile click to only affect first intersected cube

### DIFF
--- a/components/GameCanvas.tsx
+++ b/components/GameCanvas.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
+import { Canvas, useFrame, ThreeEvent } from '@react-three/fiber';
 import { OrbitControls, PerspectiveCamera, Text } from '@react-three/drei';
 import * as THREE from 'three';
 
@@ -26,8 +26,12 @@ const Tile: React.FC<TileProps> = ({ index, value, size, cubeSize, onClick }) =>
     0,
     (y - size / 2 + 0.5) * cubeSize,
   ];
+  const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+    event.stopPropagation();
+    onClick(index);
+  };
   return (
-    <mesh position={position} onPointerDown={() => onClick(index)}>
+    <mesh position={position} onPointerDown={handlePointerDown}>
       <boxGeometry args={[cubeSize - 0.05, cubeSize - 0.05, cubeSize - 0.05]} />
       <meshStandardMaterial color="orange" />
       <Text
@@ -43,7 +47,6 @@ const Tile: React.FC<TileProps> = ({ index, value, size, cubeSize, onClick }) =>
     </mesh>
   );
 };
-
 
 const Scene: React.FC<GameCanvasProps> = ({ board, size, onTileClick }) => {
   const cameraRef = useRef<THREE.PerspectiveCamera>(null!);


### PR DESCRIPTION
## Summary
- ensure mesh click handlers stop propagation so only the closest cube responds
- type pointer handlers using R3F events

## Testing
- `npx prettier --write components/GameCanvas.tsx`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685000710494832e85e8b07224c03238